### PR TITLE
增加依赖确保总是编译hwmon-pwmfan内核模块

### DIFF
--- a/fancontrol/Makefile
+++ b/fancontrol/Makefile
@@ -17,6 +17,7 @@ define Package/fancontrol
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=FanControl for OpenWRT
+  DEPENDS:=+kmod-hwmon-pwmfan
 endef
 
 define Package/fancontrol/description


### PR DESCRIPTION
对于某些没有默认编译该内核模块的设备，pwm-fan下没有hwmon/pwm1文件导致无法使用
通过增加依赖确保hwmon-pwmfan功能可用
已在鲁班猫2/自制底板验证可用